### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ pydocverter
 
 Python client for Docverter_ service
 
-.. image:: https://pypip.in/version/pydocverter/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/pydocverter.svg?style=flat
     :target: https://pypi.python.org/pypi/pydocverter/
     :alt: Latest Version
     


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pydocverter))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pydocverter`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.